### PR TITLE
fix: broken terrastate download

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ orbs:
   shellcheck: circleci/shellcheck@2.0.0
   aws-s3: circleci/aws-s3@3.1.1
   circleci-cli: circleci/circleci-cli@0.1.9
-  semantic-release: trustedshops-public/semantic-release@5.1.1
+  semantic-release: trustedshops-public/semantic-release@6.0.0
 
 commands:
   upload_for_publish:

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  terraform: circleci/terraform@3.0.0
+  terraform: circleci/terraform@3.3.0
   github-utils: trustedshops-public/github-utils@1.0.0
 
 description: |

--- a/src/commands/install_terrastate.yml
+++ b/src/commands/install_terrastate.yml
@@ -6,7 +6,7 @@ parameters:
     type: string
     description: Version of terrastate to install
     # renovate: datasource=github-releases depName=janritter/terrastate
-    default: v2.2.2
+    default: 2.0.0
 
 steps:
   - run:

--- a/src/examples/job_terraform_apply.yml
+++ b/src/examples/job_terraform_apply.yml
@@ -5,11 +5,11 @@ usage:
     terraform-utils: trustedshops-public/terraform-utils@<version>
   workflows:
     version: 2
-    continious:
+    continuous:
       jobs:
         - terraform-utils/terraform_apply:
             name: deploy-prod
-            terraform_version: 1.0.11
+            terraform_version: 1.9.7
             path: terraform
             var_file: vars/prod.tfvars
             filters:

--- a/src/examples/job_terraform_apply_with_circleci_ip_range.yml
+++ b/src/examples/job_terraform_apply_with_circleci_ip_range.yml
@@ -5,11 +5,11 @@ usage:
     terraform-utils: trustedshops-public/terraform-utils@<version>
   workflows:
     version: 2
-    continious:
+    continuous:
       jobs:
         - terraform-utils/terraform_apply_with_circleci_ip_range:
             name: deploy-prod
-            terraform_version: 1.0.11
+            terraform_version: 1.9.7
             path: terraform
             var_file: vars/prod.tfvars
             filters:

--- a/src/examples/job_terraform_apply_with_tfenv.yml
+++ b/src/examples/job_terraform_apply_with_tfenv.yml
@@ -5,11 +5,11 @@ usage:
     terraform-utils: trustedshops-public/terraform-utils@<version>
   workflows:
     version: 2
-    continious:
+    continuous:
       jobs:
         - terraform-utils/terraform_apply:
             name: deploy-prod
-            tfenv_version: v2.2.2
+            tfenv_version: v3.0.0
             path: terraform
             var_file: vars/prod.tfvars
             filters:

--- a/src/examples/job_terraform_apply_with_tfenv_and_terrastate.yml
+++ b/src/examples/job_terraform_apply_with_tfenv_and_terrastate.yml
@@ -5,12 +5,12 @@ usage:
     terraform-utils: trustedshops-public/terraform-utils@<version>
   workflows:
     version: 2
-    continious:
+    continuous:
       jobs:
         - terraform-utils/terraform_apply:
             name: deploy-prod
-            tfenv_version: v2.2.2
-            terrastate_version: 1.10.0
+            tfenv_version: v3.0.0
+            terrastate_version: 2.0.0
             path: terraform
             var_file: vars/prod.tfvars
             post_apply_steps:


### PR DESCRIPTION
## Description
The default value for the terrastate parameter uses a non-existent tag. This has been fixed to use the latest current release. On top, few minor changes regarding QoL happened such as an update of the terraform orb to support newer terraform versions.
