### PR TITLE
feat!: update terrastate to 2.2.1 with tar.gz release format

### DIFF
--- a/src/commands/install_terrastate.yml
+++ b/src/commands/install_terrastate.yml
@@ -6,12 +6,15 @@ parameters:
     type: string
     description: Version of terrastate to install
     # renovate: datasource=github-releases depName=janritter/terrastate
-    default: 2.1.1
+    default: 2.2.1
 
 steps:
   - run:
       name: Install terrastate
       command: |
-        sudo curl -L -o /usr/bin/terrastate https://github.com/janritter/terrastate/releases/download/<<parameters.version>>/linux_amd64_terrastate
+        curl -L -o /tmp/terrastate.tar.gz https://github.com/janritter/terrastate/releases/download/<<parameters.version>>/terrastate_linux_amd64.tar.gz
+        tar -xzf /tmp/terrastate.tar.gz -C /tmp
+        sudo mv /tmp/terrastate /usr/bin/terrastate
         sudo chmod +x /usr/bin/terrastate
+        rm /tmp/terrastate.tar.gz
         terrastate version

--- a/src/examples/job_terraform_apply_with_tfenv_and_terrastate.yml
+++ b/src/examples/job_terraform_apply_with_tfenv_and_terrastate.yml
@@ -10,7 +10,7 @@ usage:
         - terraform-utils/terraform_apply:
             name: deploy-prod
             tfenv_version: v3.0.0
-            terrastate_version: 2.0.0
+            terrastate_version: 2.2.1
             path: terraform
             var_file: vars/prod.tfvars
             post_apply_steps:


### PR DESCRIPTION
BREAKING CHANGE: terrastate releases are now distributed as tar.gz archives instead of raw binaries. The install command now downloads and extracts the archive.