### PR TITLE
feat: add terraform_plan jobs and plan command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,25 +74,25 @@ workflows:
   continious:
     jobs:
       - orb-tools/lint:
-          <<: *filter_all
+          !!merge <<: *filter_all
       - orb-tools/pack:
-          <<: *filter_all
+          !!merge <<: *filter_all
       - shellcheck/check:
           dir: ./src/scripts
           exclude: SC2148
-          <<: *filter_all
+          !!merge <<: *filter_all
       - publish-dev:
-          <<: *require_tests
+          !!merge <<: *require_tests
           context:
             - circleci-orbs
       - publish:
-          <<: *require_tests
-          <<: *filter_tags
+          !!merge <<: *require_tests
+          !!merge <<: *filter_tags
           context:
             - circleci-orbs
       - semantic-release/with_changelog_github_config:
           name: semantic-release
-          <<: *require_tests
+          !!merge <<: *require_tests
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,25 +74,25 @@ workflows:
   continious:
     jobs:
       - orb-tools/lint:
-          !!merge <<: *filter_all
+          <<: *filter_all
       - orb-tools/pack:
-          !!merge <<: *filter_all
+          <<: *filter_all
       - shellcheck/check:
           dir: ./src/scripts
           exclude: SC2148
-          !!merge <<: *filter_all
+          <<: *filter_all
       - publish-dev:
-          !!merge <<: *require_tests
+          <<: *require_tests
           context:
             - circleci-orbs
       - publish:
-          !!merge <<: *require_tests
-          !!merge <<: *filter_tags
+          <<: *require_tests
+          <<: *filter_tags
           context:
             - circleci-orbs
       - semantic-release/with_changelog_github_config:
           name: semantic-release
-          !!merge <<: *require_tests
+          <<: *require_tests
           filters:
             branches:
               only:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,9 +23,14 @@ repos:
       - id: fix-byte-order-marker
       - id: destroyed-symlinks
 
+  - repo: https://github.com/google/yamlfmt
+    rev: v0.21.0
+    hooks:
+      - id: yamlfmt
+
   - repo: https://github.com/syntaqx/git-hooks
     rev: v0.0.18
     hooks:
       - id: circleci-config-validate
       - id: shellcheck
-        args: [ '-e2148' ]
+        args: ['-e2148']

--- a/.yamlfmt
+++ b/.yamlfmt
@@ -1,0 +1,10 @@
+formatter:
+  type: basic
+  indent: 2
+  include_document_start: false
+  retain_line_breaks_single: true
+  scan_folded_as_literal: true
+  trim_trailing_whitespace: true
+  eof_newline: true
+  max_line_length: 200
+  pad_line_comments: 2

--- a/.yamlfmt
+++ b/.yamlfmt
@@ -8,3 +8,4 @@ formatter:
   eof_newline: true
   max_line_length: 200
   pad_line_comments: 2
+  drop_merge_tag: true

--- a/.yamllint
+++ b/.yamllint
@@ -1,6 +1,6 @@
 extends: relaxed
 
 rules:
-    line-length:
-        max: 200
-        allow-non-breakable-inline-mappings: true
+  line-length:
+    max: 200
+    allow-non-breakable-inline-mappings: true

--- a/src/commands/install_terrastate.yml
+++ b/src/commands/install_terrastate.yml
@@ -11,7 +11,7 @@ parameters:
 steps:
   - run:
       name: Install terrastate
-      command: |
+      command: |-
         curl -L -o /tmp/terrastate.tar.gz https://github.com/janritter/terrastate/releases/download/<<parameters.version>>/terrastate_linux_amd64.tar.gz
         tar -xzf /tmp/terrastate.tar.gz -C /tmp
         sudo mv /tmp/terrastate /usr/bin/terrastate

--- a/src/commands/install_tfenv.yml
+++ b/src/commands/install_tfenv.yml
@@ -11,7 +11,7 @@ parameters:
 steps:
   - run:
       name: Install tfenv
-      command: |
+      command: |-
         git clone https://github.com/tfutils/tfenv.git --depth=1 --branch <<parameters.version>> ~/.tfenv
         echo 'export PATH="$HOME/.tfenv/bin:$PATH"' >> $BASH_ENV
         source $BASH_ENV

--- a/src/commands/install_tools.yml
+++ b/src/commands/install_tools.yml
@@ -19,21 +19,21 @@ steps:
   - unless:
       condition:
         and:
-          - equal: [ <<parameters.tfenv_version>>, "none" ]
+          - equal: [<<parameters.tfenv_version>>, "none"]
       steps:
         - install_tfenv:
             version: <<parameters.tfenv_version>>
   - unless:
       condition:
         and:
-          - equal: [ <<parameters.terrastate_version>>, "none" ]
+          - equal: [<<parameters.terrastate_version>>, "none"]
       steps:
         - install_terrastate:
             version: <<parameters.terrastate_version>>
   - unless:
       condition:
         and:
-          - equal: [ <<parameters.terraform_version>>, "none" ]
+          - equal: [<<parameters.terraform_version>>, "none"]
       steps:
         - terraform/install:
             terraform_version: <<parameters.terraform_version>>

--- a/src/commands/install_tools.yml
+++ b/src/commands/install_tools.yml
@@ -11,7 +11,7 @@ parameters:
     default: none
     type: string
   terraform_version:
-    description: Verion of terraform to install
+    description: Version of terraform to install
     default: none
     type: string
 

--- a/src/commands/plan.yml
+++ b/src/commands/plan.yml
@@ -1,0 +1,108 @@
+description: >
+  Plan a terraform module
+
+parameters:
+  tfenv_version:
+    description: Version of the tfenv to install
+    default: none
+    type: string
+  terrastate_version:
+    description: Version of terrastate to install
+    default: none
+    type: string
+  terraform_version:
+    description: Version of terraform to install
+    default: none
+    type: string
+  path:
+    description: Path to terraform module
+    default: .
+    type: string
+  var_file:
+    default: vars.tfvars
+    description: Variable file to use
+    type: string
+  cli_config_file:
+    default: ''
+    description: Path to terraform cli config file
+    type: string
+  post_plan_steps:
+    type: steps
+    description: Steps to execute after planning terraform code
+    default: []
+  pre_init_steps:
+    type: steps
+    description: Steps to execute before initializing terraform
+    default: []
+  post_init_steps:
+    type: steps
+    description: Steps to execute after initializing terraform code
+    default: []
+  rewrite_github_clone_url:
+    type: boolean
+    default: false
+    description: Rewrite git urls for github to use https with env var GITHUB_TOKEN
+  attach_workspace:
+    default: true
+    description: >
+      Boolean for whether or not to attach to an existing workspace.
+    type: boolean
+  checkout:
+    default: true
+    description: >
+      Boolean for whether or not to checkout sources
+    type: boolean
+  workspace_root:
+    default: .
+    description: >
+      Workspace root path that is either an absolute path or a path relative to
+      the working directory.
+    type: string
+
+steps:
+  - when:
+      condition: <<parameters.checkout>>
+      steps:
+        - checkout
+  - when:
+      condition: <<parameters.attach_workspace>>
+      steps:
+        - attach_workspace:
+            at: <<parameters.workspace_root>>
+  - install_tools:
+      tfenv_version: <<parameters.tfenv_version>>
+      terrastate_version: <<parameters.terrastate_version>>
+      terraform_version: <<parameters.terraform_version>>
+  - unless:
+      condition:
+        and:
+          - equal: [<<parameters.terrastate_version>>, "none"]
+      steps:
+        - terrastate_init:
+            path: <<parameters.path>>
+            cli_config_file: <<parameters.cli_config_file>>
+            var_file: <<parameters.var_file>>
+  - when:
+      condition: <<parameters.rewrite_github_clone_url>>
+      steps:
+        - github-utils/rewrite_urls_with_token
+  - unless:
+      condition:
+        and:
+          - equal: [<<parameters.tfenv_version>>, "none"]
+      steps:
+        - run:
+            name: Install terraform version for module
+            command: |
+              cd <<parameters.path>>
+              tfenv install && tfenv use
+  - <<parameters.pre_init_steps>>
+  - terraform/init:
+      path: <<parameters.path>>
+      cli_config_file: <<parameters.cli_config_file>>
+  - <<parameters.post_init_steps>>
+  - terraform/plan:
+      path: <<parameters.path>>
+      cli_config_file: <<parameters.cli_config_file>>
+      var_file: <<parameters.var_file>>
+  - <<parameters.post_plan_steps>>

--- a/src/commands/provision.yml
+++ b/src/commands/provision.yml
@@ -11,7 +11,7 @@ parameters:
     default: none
     type: string
   terraform_version:
-    description: Verion of terraform to install
+    description: Version of terraform to install
     default: none
     type: string
   path:
@@ -59,7 +59,8 @@ parameters:
   workspace_root:
     default: .
     description: >
-      Workspace root path that is either an absolute path or a path relative to the working directory.
+      Workspace root path that is either an absolute path or a path relative to
+      the working directory.
     type: string
 
 steps:

--- a/src/commands/provision.yml
+++ b/src/commands/provision.yml
@@ -29,19 +29,19 @@ parameters:
   pre_apply_steps:
     type: steps
     description: Steps to execute before applying terraform code
-    default: [ ]
+    default: []
   post_apply_steps:
     type: steps
     description: Steps to execute after applying terraform code
-    default: [ ]
+    default: []
   pre_init_steps:
     type: steps
     description: Steps to execute before initializing terraform
-    default: [ ]
+    default: []
   post_init_steps:
     type: steps
     description: Steps to execute after initializing terraform code
-    default: [ ]
+    default: []
   rewrite_github_clone_url:
     type: boolean
     default: false
@@ -79,7 +79,7 @@ steps:
   - unless:
       condition:
         and:
-          - equal: [ <<parameters.terrastate_version>>, "none" ]
+          - equal: [<<parameters.terrastate_version>>, "none"]
       steps:
         - terrastate_init:
             path: <<parameters.path>>
@@ -92,7 +92,7 @@ steps:
   - unless:
       condition:
         and:
-          - equal: [ <<parameters.tfenv_version>>, "none" ]
+          - equal: [<<parameters.tfenv_version>>, "none"]
       steps:
         - run:
             name: Install terraform version for module

--- a/src/commands/terrastate_init.yml
+++ b/src/commands/terrastate_init.yml
@@ -18,6 +18,6 @@ parameters:
 steps:
   - run:
       name: Initialize terrastate
-      command: |
+      command: |-
         cd <<parameters.path>>
         terrastate --var-file <<parameters.var_file>>

--- a/src/examples/job_terraform_apply.yml
+++ b/src/examples/job_terraform_apply.yml
@@ -14,4 +14,4 @@ usage:
             var_file: vars/prod.tfvars
             filters:
               branches:
-                only: [ main ]
+                only: [main]

--- a/src/examples/job_terraform_apply_with_circleci_ip_range.yml
+++ b/src/examples/job_terraform_apply_with_circleci_ip_range.yml
@@ -14,4 +14,4 @@ usage:
             var_file: vars/prod.tfvars
             filters:
               branches:
-                only: [ main ]
+                only: [main]

--- a/src/examples/job_terraform_apply_with_tfenv.yml
+++ b/src/examples/job_terraform_apply_with_tfenv.yml
@@ -14,4 +14,4 @@ usage:
             var_file: vars/prod.tfvars
             filters:
               branches:
-                only: [ main ]
+                only: [main]

--- a/src/examples/job_terraform_apply_with_tfenv_and_terrastate.yml
+++ b/src/examples/job_terraform_apply_with_tfenv_and_terrastate.yml
@@ -19,4 +19,4 @@ usage:
                   command: .circleci/notify-deployment.sh prod
             filters:
               branches:
-                only: [ main ]
+                only: [main]

--- a/src/examples/job_terraform_plan.yml
+++ b/src/examples/job_terraform_plan.yml
@@ -1,0 +1,17 @@
+description: Terraform plan job
+usage:
+  version: 2.1
+  orbs:
+    terraform-utils: trustedshops-public/terraform-utils@<version>
+  workflows:
+    version: 2
+    continuous:
+      jobs:
+        - terraform-utils/terraform_plan:
+            name: plan-prod
+            terraform_version: 1.9.7
+            path: terraform
+            var_file: vars/prod.tfvars
+            filters:
+              branches:
+                only: [main]

--- a/src/examples/job_terraform_plan_with_circleci_ip_range.yml
+++ b/src/examples/job_terraform_plan_with_circleci_ip_range.yml
@@ -1,0 +1,17 @@
+description: Terraform plan job using CircleCI IP ranges
+usage:
+  version: 2.1
+  orbs:
+    terraform-utils: trustedshops-public/terraform-utils@<version>
+  workflows:
+    version: 2
+    continuous:
+      jobs:
+        - terraform-utils/terraform_plan_with_circleci_ip_range:
+            name: plan-prod
+            terraform_version: 1.9.7
+            path: terraform
+            var_file: vars/prod.tfvars
+            filters:
+              branches:
+                only: [main]

--- a/src/jobs/terraform_apply.yml
+++ b/src/jobs/terraform_apply.yml
@@ -16,7 +16,7 @@ parameters:
     default: none
     type: string
   terraform_version:
-    description: Verion of terraform to install
+    description: Version of terraform to install
     default: none
     type: string
   path:

--- a/src/jobs/terraform_apply.yml
+++ b/src/jobs/terraform_apply.yml
@@ -1,5 +1,5 @@
 description: >
-  Provision a terraform module with circleci ip range
+  Provision a terraform module
 
 executor: default
 
@@ -64,7 +64,8 @@ parameters:
   workspace_root:
     default: .
     description: >
-      Workspace root path that is either an absolute path or a path relative to the working directory.
+      Workspace root path that is either an absolute path or a path relative to
+      the working directory.
     type: string
 
 steps:

--- a/src/jobs/terraform_apply.yml
+++ b/src/jobs/terraform_apply.yml
@@ -34,19 +34,19 @@ parameters:
   pre_apply_steps:
     type: steps
     description: Steps to execute before applying terraform code
-    default: [ ]
+    default: []
   post_apply_steps:
     type: steps
     description: Steps to execute after applying terraform code
-    default: [ ]
+    default: []
   pre_init_steps:
     type: steps
     description: Steps to execute before initializing terraform
-    default: [ ]
+    default: []
   post_init_steps:
     type: steps
     description: Steps to execute after initializing terraform code
-    default: [ ]
+    default: []
   rewrite_github_clone_url:
     type: boolean
     default: false

--- a/src/jobs/terraform_apply_with_circleci_ip_range.yml
+++ b/src/jobs/terraform_apply_with_circleci_ip_range.yml
@@ -18,7 +18,7 @@ parameters:
     default: none
     type: string
   terraform_version:
-    description: Verion of terraform to install
+    description: Version of terraform to install
     default: none
     type: string
   path:
@@ -66,7 +66,8 @@ parameters:
   workspace_root:
     default: .
     description: >
-      Workspace root path that is either an absolute path or a path relative to the working directory.
+      Workspace root path that is either an absolute path or a path relative to
+      the working directory.
     type: string
 
 steps:

--- a/src/jobs/terraform_apply_with_circleci_ip_range.yml
+++ b/src/jobs/terraform_apply_with_circleci_ip_range.yml
@@ -36,19 +36,19 @@ parameters:
   pre_apply_steps:
     type: steps
     description: Steps to execute before applying terraform code
-    default: [ ]
+    default: []
   post_apply_steps:
     type: steps
     description: Steps to execute after applying terraform code
-    default: [ ]
+    default: []
   pre_init_steps:
     type: steps
     description: Steps to execute before initializing terraform
-    default: [ ]
+    default: []
   post_init_steps:
     type: steps
     description: Steps to execute after initializing terraform code
-    default: [ ]
+    default: []
   rewrite_github_clone_url:
     type: boolean
     default: false

--- a/src/jobs/terraform_plan.yml
+++ b/src/jobs/terraform_plan.yml
@@ -1,0 +1,81 @@
+description: >
+  Plan a terraform module
+
+executor: default
+
+environment:
+  TF_IN_AUTOMATION: 1
+
+parameters:
+  tfenv_version:
+    description: Version of the tfenv to install
+    default: none
+    type: string
+  terrastate_version:
+    description: Version of terrastate to install
+    default: none
+    type: string
+  terraform_version:
+    description: Version of terraform to install
+    default: none
+    type: string
+  path:
+    description: Path to terraform module
+    default: .
+    type: string
+  var_file:
+    default: vars.tfvars
+    description: Variable file to use
+    type: string
+  cli_config_file:
+    default: ''
+    description: Path to terraform cli config file
+    type: string
+  post_plan_steps:
+    type: steps
+    description: Steps to execute after planning terraform code
+    default: []
+  pre_init_steps:
+    type: steps
+    description: Steps to execute before initializing terraform
+    default: []
+  post_init_steps:
+    type: steps
+    description: Steps to execute after initializing terraform code
+    default: []
+  rewrite_github_clone_url:
+    type: boolean
+    default: false
+    description: Rewrite git urls for github to use https with env var GITHUB_TOKEN
+  attach_workspace:
+    default: true
+    description: >
+      Boolean for whether or not to attach to an existing workspace.
+    type: boolean
+  checkout:
+    default: true
+    description: >
+      Boolean for whether or not to checkout sources
+    type: boolean
+  workspace_root:
+    default: .
+    description: >
+      Workspace root path that is either an absolute path or a path relative to
+      the working directory.
+    type: string
+
+steps:
+  - plan:
+      tfenv_version: <<parameters.tfenv_version>>
+      terrastate_version: <<parameters.terrastate_version>>
+      terraform_version: <<parameters.terraform_version>>
+      path: <<parameters.path>>
+      var_file: <<parameters.var_file>>
+      cli_config_file: <<parameters.cli_config_file>>
+      post_plan_steps: <<parameters.post_plan_steps>>
+      pre_init_steps: <<parameters.pre_init_steps>>
+      post_init_steps: <<parameters.post_init_steps>>
+      rewrite_github_clone_url: <<parameters.rewrite_github_clone_url>>
+      attach_workspace: <<parameters.attach_workspace>>
+      checkout: <<parameters.checkout>>
+      workspace_root: <<parameters.workspace_root>>

--- a/src/jobs/terraform_plan_with_circleci_ip_range.yml
+++ b/src/jobs/terraform_plan_with_circleci_ip_range.yml
@@ -1,0 +1,83 @@
+description: >
+  Plan a terraform module with circleci ip range
+
+executor: default
+
+environment:
+  TF_IN_AUTOMATION: 1
+
+circleci_ip_ranges: true
+
+parameters:
+  tfenv_version:
+    description: Version of the tfenv to install
+    default: none
+    type: string
+  terrastate_version:
+    description: Version of terrastate to install
+    default: none
+    type: string
+  terraform_version:
+    description: Version of terraform to install
+    default: none
+    type: string
+  path:
+    description: Path to terraform module
+    default: .
+    type: string
+  var_file:
+    default: vars.tfvars
+    description: Variable file to use
+    type: string
+  cli_config_file:
+    default: ''
+    description: Path to terraform cli config file
+    type: string
+  post_plan_steps:
+    type: steps
+    description: Steps to execute after planning terraform code
+    default: []
+  pre_init_steps:
+    type: steps
+    description: Steps to execute before initializing terraform
+    default: []
+  post_init_steps:
+    type: steps
+    description: Steps to execute after initializing terraform code
+    default: []
+  rewrite_github_clone_url:
+    type: boolean
+    default: false
+    description: Rewrite git urls for github to use https with env var GITHUB_TOKEN
+  attach_workspace:
+    default: true
+    description: >
+      Boolean for whether or not to attach to an existing workspace.
+    type: boolean
+  checkout:
+    default: true
+    description: >
+      Boolean for whether or not to checkout sources
+    type: boolean
+  workspace_root:
+    default: .
+    description: >
+      Workspace root path that is either an absolute path or a path relative to
+      the working directory.
+    type: string
+
+steps:
+  - plan:
+      tfenv_version: <<parameters.tfenv_version>>
+      terrastate_version: <<parameters.terrastate_version>>
+      terraform_version: <<parameters.terraform_version>>
+      path: <<parameters.path>>
+      var_file: <<parameters.var_file>>
+      cli_config_file: <<parameters.cli_config_file>>
+      post_plan_steps: <<parameters.post_plan_steps>>
+      pre_init_steps: <<parameters.pre_init_steps>>
+      post_init_steps: <<parameters.post_init_steps>>
+      rewrite_github_clone_url: <<parameters.rewrite_github_clone_url>>
+      attach_workspace: <<parameters.attach_workspace>>
+      checkout: <<parameters.checkout>>
+      workspace_root: <<parameters.workspace_root>>


### PR DESCRIPTION
## Description

Adds `terraform_plan` jobs to the orb to be able to run a plan-only pipeline. Also includes some house-keeping that came up along the way.

### What's new
- New command `plan` mirroring `provision`, but stopping after `terraform plan`
- New job `terraform_plan` for the standard executor
- New job `terraform_plan_with_circleci_ip_range` for runs that need CircleCI's IP ranges

### House-keeping
- Repo-wide YAML formatting via `yamlfmt` (new `.yamlfmt` config, pre-commit hook)
- Fixed `Verion` → `Version` typo across several parameter descriptions
- Corrected the `terraform_apply` job description (no longer mentions IP ranges)