### PR TITLE
feat(jobs): make executor configurable via parameter

### DIFF
--- a/src/jobs/apply.yml
+++ b/src/jobs/apply.yml
@@ -4,12 +4,16 @@ description: >
   Uses a saved plan (-out=tfplan) so apply applies exactly the plan that was
   produced earlier in the same job, with no possibility of drift.
 
-executor: default
+executor: <<parameters.executor>>
 
 environment:
   TF_IN_AUTOMATION: 1
 
 parameters:
+  executor:
+    description: Executor to run the job on
+    default: default
+    type: executor
   tfenv_version:
     description: Version of tfenv to install. Default "none" skips installation.
     default: none

--- a/src/jobs/destroy.yml
+++ b/src/jobs/destroy.yml
@@ -6,12 +6,16 @@ description: >
   with a custom step that calls `terraform plan -destroy`, then apply
   the persisted tfplan via the `apply` job.
 
-executor: default
+executor: <<parameters.executor>>
 
 environment:
   TF_IN_AUTOMATION: 1
 
 parameters:
+  executor:
+    description: Executor to run the job on
+    default: default
+    type: executor
   tfenv_version:
     description: Version of tfenv to install. Default "none" skips installation.
     default: none

--- a/src/jobs/docs.yml
+++ b/src/jobs/docs.yml
@@ -10,9 +10,13 @@ description: >
   to push to main/master. Requires git authentication to be configured
   by the caller (see pre_commit_steps).
 
-executor: default
+executor: <<parameters.executor>>
 
 parameters:
+  executor:
+    description: Executor to run the job on
+    default: default
+    type: executor
   terraform_docs_version:
     description: Version of terraform-docs to install (e.g. v0.20.0)
     # renovate: datasource=github-releases depName=terraform-docs/terraform-docs

--- a/src/jobs/fmt.yml
+++ b/src/jobs/fmt.yml
@@ -10,12 +10,16 @@ description: >
   Requires git authentication to be configured (typically via
   github-utils/rewrite_urls_with_token in pre_commit_steps).
 
-executor: default
+executor: <<parameters.executor>>
 
 environment:
   TF_IN_AUTOMATION: 1
 
 parameters:
+  executor:
+    description: Executor to run the job on
+    default: default
+    type: executor
   tfenv_version:
     description: Version of tfenv to install. Default "none" skips installation.
     default: none

--- a/src/jobs/init.yml
+++ b/src/jobs/init.yml
@@ -3,12 +3,16 @@ description: >
   persist the resulting .terraform/ directory to the CircleCI workspace so
   downstream jobs can reuse providers and backend config without re-running init.
 
-executor: default
+executor: <<parameters.executor>>
 
 environment:
   TF_IN_AUTOMATION: 1
 
 parameters:
+  executor:
+    description: Executor to run the job on
+    default: default
+    type: executor
   tfenv_version:
     description: Version of tfenv to install. Default "none" skips installation.
     default: none

--- a/src/jobs/lint.yml
+++ b/src/jobs/lint.yml
@@ -5,9 +5,13 @@ description: >
   declared in .tflint.hcl, then runs the linter. Fails the job if
   tflint reports any issues.
 
-executor: default
+executor: <<parameters.executor>>
 
 parameters:
+  executor:
+    description: Executor to run the job on
+    default: default
+    type: executor
   tflint_version:
     description: Version of tflint to install (e.g. v0.62.0)
     # renovate: datasource=github-releases depName=terraform-linters/tflint

--- a/src/jobs/plan.yml
+++ b/src/jobs/plan.yml
@@ -3,12 +3,16 @@ description: >
   tfplan file is persisted to the CircleCI workspace at <path>/tfplan so a
   downstream job can apply exactly that plan (e.g. after manual approval).
 
-executor: default
+executor: <<parameters.executor>>
 
 environment:
   TF_IN_AUTOMATION: 1
 
 parameters:
+  executor:
+    description: Executor to run the job on
+    default: default
+    type: executor
   tfenv_version:
     description: Version of tfenv to install. Default "none" skips installation.
     default: none

--- a/src/jobs/security_scan.yml
+++ b/src/jobs/security_scan.yml
@@ -5,9 +5,13 @@ description: >
   Fails the job by default if any finding at the given severity
   threshold (default HIGH and CRITICAL) is reported.
 
-executor: default
+executor: <<parameters.executor>>
 
 parameters:
+  executor:
+    description: Executor to run the job on
+    default: default
+    type: executor
   trivy_version:
     description: Version of trivy to install (e.g. v0.70.0)
     # renovate: datasource=github-releases depName=aquasecurity/trivy

--- a/src/jobs/validate.yml
+++ b/src/jobs/validate.yml
@@ -3,12 +3,16 @@ description: >
 
   Pure static check (terraform init -backend=false then terraform validate).
 
-executor: default
+executor: <<parameters.executor>>
 
 environment:
   TF_IN_AUTOMATION: 1
 
 parameters:
+  executor:
+    description: Executor to run the job on
+    default: default
+    type: executor
   tfenv_version:
     description: Version of tfenv to install. Default "none" skips installation.
     default: none


### PR DESCRIPTION
## Description

All jobs in this orb hardcoded `executor: default`, forcing consumers onto the orb's bundled `cimg/base` image. This adds an `executor` (`type: executor`, default `default`) to every job, so callers can specify their own executor. 

Backwards compatible: the default keeps existing behavior unchanged.