### PR TITLE
fix(renovate): repair custom-manager regex and circle ci yaml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,8 +86,7 @@ workflows:
           context:
             - circleci-orbs
       - publish:
-          <<: *require_tests
-          <<: *filter_tags
+          <<: [*require_tests, *filter_tags]
           context:
             - circleci-orbs
       - semantic-release/with_changelog_github_config:

--- a/renovate.json
+++ b/renovate.json
@@ -10,9 +10,10 @@
         "/^src/.*yml$/"
       ],
       "matchStrings": [
-        "datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s.*?default: (?<currentValue>.*)"
+        "datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: extractVersion=(?<extractVersion>\\S+))?(?: versioning=(?<versioning>\\S+))?\\s.*?default: \"?(?<currentValue>[^\"\\s]+)\"?"
       ],
-      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}",
+      "extractVersionTemplate": "{{#if extractVersion}}{{{extractVersion}}}{{/if}}"
     }
   ]
 }


### PR DESCRIPTION
## Description
<!-- Short description about the change, what have you done? -->

The customManager regex used non-greedy `.*?` for depName, which on the only line carrying `extractVersion=...` backtracked across the newline and produced an invalid depName like
`hashicorp/terraform extractVersion=^v(?<version>.*)$`

.circleci/config.yml used YAML 1.1 multi-merge (`<<: *a` then `<<: *b`), which Renovate's YAML 1.2 parser rejects as a duplicate key. The file failed extraction and all 5 orbs were silently dropped