### PR TITLE
chore: add src dir to circleci matcher in renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,14 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "local>trustedshops-public/.github:renovate-config"
+    "github>trustedshops-public/.github:renovate-config"
   ],
+  "circleci": {
+    "managerFilePatterns": [
+      "/(^|/)\\.circleci/.+\\.ya?ml$/",
+      "src/**/*.yml"
+    ]
+  },
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
# Description
Expand the matcher for `circleci` to include the `src/` directory to get updates for additional files e.g. `@orb.yml`.
